### PR TITLE
Use internal_macro_calls=1 to indicate that we generate one new macro call internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 proc-macro2 = "1.0.3"
-proc-macro-hack = "0.5.9"
+proc-macro-hack = "0.5.10"
 proc-macro-nested = "0.1.3"
 proc_macro_hack_bug_impl = { path = "./proc_macro_hack_bug_impl" }
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features=["async-await"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use futures::join;
 
 use proc_macro_hack::proc_macro_hack;
 
-#[proc_macro_hack(support_nested)]
+#[proc_macro_hack(support_nested, internal_macro_calls = 1)]
 pub use proc_macro_hack_bug_impl::join_all;
 
 #[allow(dead_code)]


### PR DESCRIPTION
Fixes https://github.com/dtolnay/proc-macro-hack/issues/41.

The line `#[proc_macro_hack(support_nested, internal_macro_calls = 1)]` means that this macro internally creates one new call to a proc-macro-hack macro (futures::join) that is not visible in the arguments.